### PR TITLE
copy secret from local filesystem to container

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine
+FROM golang:1.19-alpine 
  
 # Create a directory for the app
 RUN mkdir /app
@@ -8,10 +8,11 @@ COPY . /app
  
 # Set working directory
 WORKDIR /app
- 
+COPY ~/service-account.json /root
 # Run command as described:
 # go build will build an executable file named server in the current directory
 RUN go build -o server . 
- 
+
+
 # Run the server executable
 CMD [ "/app/server" ]


### PR DESCRIPTION

The deployment doesn't include the secret key.
Therefore we can't auth against firestore.

The key has been added to the deployment server, but we now need to copy it to the container.