### PR TITLE
Fix front login form crash

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -35,15 +35,15 @@ import { AccessControlService } from './services/authService/access-control.serv
 
 @NgModule({
   declarations: [
+    LoaderComponent,
+    LoaderDirective,
+    MessageBannerComponent,
+    HomePageComponent,
     AppComponent,
     TitleComponent,
     ButtonComponent,
     LoginPageComponent,
     PageNotFoundComponent,
-    HomePageComponent,
-    LoaderComponent,
-    LoaderDirective,
-    MessageBannerComponent,
     MesageBannerDirective,
     SignupPageComponent,
   ],

--- a/frontend/src/app/login-page/login-page.component.html
+++ b/frontend/src/app/login-page/login-page.component.html
@@ -16,14 +16,19 @@
     </mat-form-field>
 
     <button [disabled]="loginForm.invalid" mat-flat-button class="form-group" color="primary" id="login">Login</button>
-    <ng-template appMesageBanner id="banner" ></ng-template>
+    
+    <div id="errorMsg" class="banner hidden" >class="banner"> </div> 
+
+
+    <ng-template appMessageBanner id="banner" ></ng-template>
   </form>
+
   <ng-template #loggedIn >
   <p id="loggedIn">
     Already logged in !!!
   </p>
   </ng-template>
-
+  
   <ng-template appLoader ></ng-template>
 
 

--- a/frontend/src/app/login-page/login-page.component.html
+++ b/frontend/src/app/login-page/login-page.component.html
@@ -17,10 +17,8 @@
 
     <button [disabled]="loginForm.invalid" mat-flat-button class="form-group" color="primary" id="login">Login</button>
     
-    <div id="errorMsg" class="banner hidden" >class="banner"> </div> 
+    <div id="errorMsg" class="banner hidden" ></div> 
 
-
-    <ng-template appMessageBanner id="banner" ></ng-template>
   </form>
 
   <ng-template #loggedIn >

--- a/frontend/src/app/login-page/login-page.component.spec.ts
+++ b/frontend/src/app/login-page/login-page.component.spec.ts
@@ -5,12 +5,11 @@ import { LoginPageComponent } from './login-page.component';
 import { HttpClientModule } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { services } from '../services';
-
-// import { AuthInterceptor } from './../services/http-interceptors/auth-interceptor.service';
-// import { ConfigService } from "./../config/config.service";
-// import { BackendLinkService } from "./../services/backendservice/backend-link.service";
-// import { HttpErrorService } from './../services/http-interceptors/http-error.service';
-// import { TokenService } from "./../services/authService/token-service.service";
+import { ReactiveFormsModule } from '@angular/forms';
+import { LoaderComponent } from '../loader/loader.component';
+import { LoaderDirective } from '../loader/loader.directive';
+import { MesageBannerDirective } from '../message-banner/mesage-banner.directive';
+import { MessageBannerComponent } from '../message-banner/message-banner.component';
 
 describe('LoginPageComponent', () => {
   let component: LoginPageComponent;
@@ -18,13 +17,16 @@ describe('LoginPageComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule,
-                HttpClientModule,
-              ],
-      declarations: [ LoginPageComponent],
-      providers: services
-    })
-    .compileComponents();
+      imports: [HttpClientTestingModule, HttpClientModule, ReactiveFormsModule],
+      declarations: [
+        LoginPageComponent,
+        MesageBannerDirective,
+        MessageBannerComponent,
+        LoaderComponent,
+        LoaderDirective,
+      ],
+      providers: services,
+    }).compileComponents();
 
     fixture = TestBed.createComponent(LoginPageComponent);
     component = fixture.componentInstance;
@@ -38,5 +40,23 @@ describe('LoginPageComponent', () => {
   it('should not crash on first call of removeMessage()', () => {
     component.removeMessage();
     expect(component).toBeTruthy();
-  })
+  });
+
+  /**
+   * integration tests
+   */
+
+  it('Schould create loader', () => {
+    expect(
+      component.dynamicChild?.viewContainerRef.createComponent(LoaderComponent)
+    ).toBeTruthy();
+  });
+
+  it('should display message in banner', () => {
+    component.displayMessage('test message');
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('.banner')?.textContent).toContain(
+      'test message'
+    );
+  });
 });

--- a/frontend/src/app/login-page/login-page.component.spec.ts
+++ b/frontend/src/app/login-page/login-page.component.spec.ts
@@ -34,4 +34,9 @@ describe('LoginPageComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should not crash on first call of removeMessage()', () => {
+    component.removeMessage();
+    expect(component).toBeTruthy();
+  })
 });

--- a/frontend/src/app/login-page/login-page.component.ts
+++ b/frontend/src/app/login-page/login-page.component.ts
@@ -30,7 +30,6 @@ export class LoginPageComponent {
 
   hide = true;
   loginForm: FormGroup;
-  isDisplayingMessage = false;
 
   private clicked = false;
   private loginFormInputs = { username: '', password: '' };

--- a/frontend/src/app/login-page/login-page.component.ts
+++ b/frontend/src/app/login-page/login-page.component.ts
@@ -36,6 +36,7 @@ export class LoginPageComponent {
 
   hide = true;
   clicked = false;
+  private isDisplayingMessage = false;
   loginForm: FormGroup;
   loginFormInputs = { username: '', password: '' };
 
@@ -81,8 +82,9 @@ export class LoginPageComponent {
     );
     elem.instance.message = message;
   }
+
   removeMessage() {
-    this.dynamicBanner.vcref.clear();
+    if (this.isDisplayingMessage) this.dynamicBanner.vcref.clear();
   }
 
   notLogged(): boolean {

--- a/frontend/src/app/login-page/login-page.component.ts
+++ b/frontend/src/app/login-page/login-page.component.ts
@@ -1,27 +1,18 @@
 import { Component, ViewChild } from '@angular/core';
-import {
-  FormControl,
-  FormGroup,
-  Validators,
-} from '@angular/forms';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { AuthService } from '../services/authService/auth.service';
 import { Router } from '@angular/router';
 import { LoaderComponent } from '../loader/loader.component';
 import { LoaderDirective } from '../loader/loader.directive';
-import { MesageBannerDirective } from '../message-banner/mesage-banner.directive';
-import { MessageBannerComponent } from '../message-banner/message-banner.component';
 
 @Component({
   selector: 'app-login-page',
   templateUrl: './login-page.component.html',
   styleUrls: ['./login-page.component.scss'],
-  host: { class: 'default-layout' },
+  host: { class: 'default-layout' }
 })
 export class LoginPageComponent {
-  constructor(
-    private router: Router,
-    private authService: AuthService
-  ) {
+  constructor(private router: Router, private authService: AuthService) {
     this.loginForm = new FormGroup({
       username: new FormControl(this.loginFormInputs.username, [
         Validators.required,
@@ -34,17 +25,16 @@ export class LoginPageComponent {
     });
   }
 
-  hide = true;
-  clicked = false;
-  private isDisplayingMessage = false;
-  loginForm: FormGroup;
-  loginFormInputs = { username: '', password: '' };
-
   @ViewChild(LoaderDirective, { static: true })
   dynamicChild!: LoaderDirective;
 
-  @ViewChild(MesageBannerDirective, { static: true })
-  dynamicBanner!: MesageBannerDirective;
+  hide = true;
+  loginForm: FormGroup;
+  isDisplayingMessage = false;
+
+  private clicked = false;
+  private loginFormInputs = { username: '', password: '' };
+
 
   onSubmit() {
     if (this.loginForm.invalid) return;
@@ -55,12 +45,14 @@ export class LoginPageComponent {
     this.authService.clearError();
     this.removeMessage();
 
+    // Call the method that send login request to the server
     this.authService
       .login(this.loginForm.value.username, this.loginForm.value.password)
       .add(() => {
         if (typeof this.authService.getError() !== 'undefined') {
           this.clicked = false;
-          this.removeLoader();          
+          this.removeLoader();
+          this.displayMessage("tadada");
           this.displayMessage(this.authService.getError());
         } else {
           this.router.navigate(['/home']);
@@ -77,14 +69,21 @@ export class LoginPageComponent {
   }
 
   displayMessage(message: string) {
-    const elem = this.dynamicBanner.vcref.createComponent(
-      MessageBannerComponent
-    );
-    elem.instance.message = message;
+    const elem = document.querySelector("#errorMsg");
+    if (elem) {
+      elem.innerHTML = message;
+      elem.classList.add('visible');
+      elem.classList.remove('hidden');
+    }
   }
 
   removeMessage() {
-    if (this.isDisplayingMessage) this.dynamicBanner.vcref.clear();
+    const elem = document.querySelector("#errorMsg");
+    if (elem) {
+      elem.innerHTML = '';
+      elem.classList.remove('visible');
+      elem.classList.add('hidden');
+    }
   }
 
   notLogged(): boolean {

--- a/frontend/src/app/message-banner/mesage-banner.directive.ts
+++ b/frontend/src/app/message-banner/mesage-banner.directive.ts
@@ -1,7 +1,7 @@
 import { Directive, ViewContainerRef } from '@angular/core';
 
 @Directive({
-  selector: '[appMesageBanner]'
+  selector: '[appMessageBanner]'
 })
 export class MesageBannerDirective {
 

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -49,3 +49,20 @@ html {
     -ms-overflow-style: none;  /* IE and Edge */
     scrollbar-width: none;  /* Firefox */
 } 
+
+.hidden {
+    visibility: hidden !important;
+}
+
+.visible {
+    visibility: visible !important;
+}
+
+.banner {
+    width: 100%;
+    color: white;
+    background-color: red;
+    text-align: center;
+    padding: 1rem;
+    margin-top: 1rem;
+}


### PR DESCRIPTION
The login page crashed because of undefined ng directive (MessageBannerDirective) in LoginPageComponent.
I investigated and concluded that this is a bug of Angular. So I removed the directive and replace it with vanilla JS.