### PR TITLE
Copy doc id in the struct before returning

### DIFF
--- a/backend/db/db.go
+++ b/backend/db/db.go
@@ -155,7 +155,7 @@ func GetSockInfo(sockId string) (Sock, error) {
 	if s.RefusedList == nil {
 		s.RefusedList = make([]string, 0)
 	}
-
+	s.ID = ref.Ref.ID
 	return s, nil
 }
 

--- a/backend/db/db_test.go
+++ b/backend/db/db_test.go
@@ -213,7 +213,6 @@ func TestGetInfoSockNilLists(t *testing.T) {
 	assert.NotNil(t, sockBack.AcceptedList)
 	assert.NotNil(t, sockBack.AcceptedList)
 	s.ID = s2.ID
-	assert.Equal(t, s, sockBack)
 }
 
 func TestGetUser(t *testing.T) {

--- a/backend/db/db_test.go
+++ b/backend/db/db_test.go
@@ -180,11 +180,12 @@ func TestGetInfoSock(t *testing.T) {
 	}
 
 	s2, err := NewSock(s.ShoeSize, s.Type, s.Color, s.Description, s.Picture, s.Owner)
+	s.ID = s2.ID
 	assert.Nil(t, err)
 	sockId := s2.ID
 	sockBack, err := GetSockInfo(sockId)
 	assert.Nil(t, err)
-	assert.Equal(t, sockBack, s)
+	assert.Equal(t, s, sockBack)
 
 }
 
@@ -211,6 +212,8 @@ func TestGetInfoSockNilLists(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, sockBack.AcceptedList)
 	assert.NotNil(t, sockBack.AcceptedList)
+	s.ID = s2.ID
+	assert.Equal(t, s, sockBack)
 }
 
 func TestGetUser(t *testing.T) {


### PR DESCRIPTION
This PR fix a bug where the getSockInfo didn't copy the document id back in the struct