### PR TITLE
Change the return type from firestoreRef to Sock in the newSock

### DIFF
--- a/backend/db/db.go
+++ b/backend/db/db.go
@@ -159,37 +159,37 @@ func GetSockInfo(sockId string) (Sock, error) {
 	return s, nil
 }
 
-func NewSock(shoeSize uint8, type_ Profile, color string, desc string, Pictureb64 string, owner string) (*firestore.DocumentRef, error) {
+func NewSock(shoeSize uint8, type_ Profile, color string, desc string, Pictureb64 string, owner string) (Sock, error) {
 	if shoeSize > 75 {
-		return nil, fmt.Errorf("show size `%d` is giant ! Are you a giant ? I don't think so", shoeSize)
+		return Sock{}, fmt.Errorf("show size `%d` is giant ! Are you a giant ? I don't think so", shoeSize)
 	}
 	if shoeSize <= 5 {
-		return nil, fmt.Errorf("show size `%d` is very small ! Are you a dwarf ? I don't think so", shoeSize)
+		return Sock{}, fmt.Errorf("show size `%d` is very small ! Are you a dwarf ? I don't think so", shoeSize)
 	}
 	if type_ >= count {
-		return nil, fmt.Errorf("type `%d` is invalid", count)
+		return Sock{}, fmt.Errorf("type `%d` is invalid", count)
 	}
 	_, err := utils.ParseHexColor(color)
 	if err != nil {
-		return nil, err
+		return Sock{}, err
 	}
 	if strings.TrimSpace(desc) == "" {
-		return nil, fmt.Errorf("description is empty")
+		return Sock{}, fmt.Errorf("description is empty")
 	}
 	if strings.TrimSpace(Pictureb64) == "" {
-		return nil, fmt.Errorf("picture is empty")
+		return Sock{}, fmt.Errorf("picture is empty")
 	}
 	// TODO: validate base64 + image data
 	client, err := GetDBConnection()
 	if err != nil {
-		return nil, err
+		return Sock{}, err
 	}
 	userSnapShot, err := client.Collection("users").Doc(owner).Get(context.Background())
 	if err != nil {
-		return nil, fmt.Errorf("user doesn't exist %s", err.Error())
+		return Sock{}, fmt.Errorf("user doesn't exist %s", err.Error())
 	}
 	if !userSnapShot.Exists() {
-		return nil, fmt.Errorf("document doesn't exist")
+		return Sock{}, fmt.Errorf("document doesn't exist")
 	}
 
 	s := Sock{
@@ -204,7 +204,8 @@ func NewSock(shoeSize uint8, type_ Profile, color string, desc string, Pictureb6
 		IsMatched:    false,
 	}
 	docRef, _, err := client.Collection("socks").Add(*ctx, s)
-	return docRef, err
+	s.ID = docRef.ID
+	return s, err
 }
 
 func createClient(ctx context.Context) (*firestore.Client, error) {

--- a/backend/db/db_test.go
+++ b/backend/db/db_test.go
@@ -151,10 +151,10 @@ func TestGetUserSocks(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Zero(t, len(socks))
 
-	doc, err = NewSock(10, low, "#000", "Super sock !", "aGkK", userID)
+	sock, err := NewSock(10, low, "#000", "Super sock !", "aGkK", userID)
 	assert.Nil(t, err)
 
-	sockID := doc.ID
+	sockID := sock.ID
 	socks, err = GetUserSocks(userID)
 
 	assert.Nil(t, err)
@@ -225,7 +225,7 @@ func TestGetUser(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, userID, docr.Ref.ID)
 
-	docr, err = GetUser("invalid")
+	_, err = GetUser("invalid")
 	assert.NotNil(t, err)
 }
 


### PR DESCRIPTION
This pr change the return type of the NewSock(...) from firestoreRef to Sock
This is needed because most of our function newX return x not firestoreRef and we want to have a slick api
